### PR TITLE
Made Terrain Node Inherit from Spatial Node

### DIFF
--- a/addons/zylann/terrain/terrain.gd
+++ b/addons/zylann/terrain/terrain.gd
@@ -1,5 +1,5 @@
 tool
-extends Node
+extends Spatial
 
 
 const Util = preload("terrain_utils.gd")

--- a/addons/zylann/terrain/terrain_plugin.gd
+++ b/addons/zylann/terrain/terrain_plugin.gd
@@ -16,7 +16,7 @@ var _panel = null
 
 
 func _enter_tree():
-	add_custom_type(TARGET_TYPE, "Node", Terrain, preload("icon.png"))
+	add_custom_type(TARGET_TYPE, "Spatial", Terrain, preload("icon.png"))
 	
 	_brush = Brush.new()
 	_brush.set_undo_redo(true)


### PR DESCRIPTION
Gizmos still do not work since the node uses mouse input when selected in the Scene Node Lists, but the changing of translation, rotation, and scale , in the Inspector still works. 
Everything seems to work fine, Live scene updates are okay, the Node changes when its parent's properties change, and there is no apparent performance hit on my pc. 

Screenshot:

![screenshot at 2016-08-14 13-40-41](https://cloud.githubusercontent.com/assets/16758490/17651109/b61e4b76-6224-11e6-89fb-0f962176898f.png)

PS:
    I am going to look into whether get_selection() can test for gizmos and if it can't I might be able to make my own gizmo tool to compare to based off of what is in this documentation [http://docs.godotengine.org/en/latest/classes/class_editorplugin.html?highlight=gizmo#class-editorplugin-create-spatial-gizmo](url)
